### PR TITLE
Fix pascalcase stealing first character from boundaries

### DIFF
--- a/caseconverter/boundaries.py
+++ b/caseconverter/boundaries.py
@@ -99,7 +99,7 @@ class OnUpperPrecededByUpperAppendCurrent(BoundaryHandler):
         self._join_char = join_char
 
     def is_boundary(self, pc, c):
-        return pc != None and pc.isalpha() and pc.isupper() and c.isupper()
+        return pc is not None and pc.isalpha() and pc.isupper() and c.isupper()
 
     def handle(self, pc, cc, input_buffer, output_buffer):
         output_buffer.write(cc)

--- a/caseconverter/pascal.py
+++ b/caseconverter/pascal.py
@@ -1,16 +1,25 @@
 from .caseconverter import CaseConverter
 from .boundaries import (
+    BoundaryHandler,
     OnDelimeterUppercaseNext,
     OnUpperPrecededByLowerAppendUpper,
     OnUpperPrecededByUpperAppendCurrent,
 )
 
+class OnFirstCharUpper(BoundaryHandler):
+    """Boundary handler that ensures the first character is uppercase."""
+
+    def is_boundary(self, pc, c):
+        return pc is None
+
+    def handle(self, pc, cc, input_buffer, output_buffer):
+        output_buffer.write(cc.upper())
+
 
 class Pascal(CaseConverter):
-    def init(self, input_buffer, output_buffer):
-        output_buffer.write(input_buffer.read(1).upper())
 
     def define_boundaries(self):
+        self.add_boundary_handler(OnFirstCharUpper())
         self.add_boundary_handler(OnDelimeterUppercaseNext(self.delimiters()))
         self.add_boundary_handler(OnUpperPrecededByLowerAppendUpper())
         self.add_boundary_handler(OnUpperPrecededByUpperAppendCurrent())

--- a/caseconverter/pascal_test.py
+++ b/caseconverter/pascal_test.py
@@ -31,6 +31,7 @@ from . import *
         # Alternating character cases
         ("heLlo WoRld", "HeLloWoRld"),
         ("helloWORLD", "HelloWORLD"),
+        ("HELLOWorld", "HELLOWorld"),
     ],
 )
 def test_pascal_with_default_args(input, output):


### PR DESCRIPTION
By picking the first character out of the input, an artificial boundary is created between first and second character. Fixed by creating a pascalcase specific boundary checking if there is no previous character.

Fixes #13 